### PR TITLE
Added support for templates using Mandrill's merge tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # parse-server-mandrill-adapter
-Used to send Parse Server password reset and email verification emails through Mandrill
+Used to send Parse Server password reset and email verification emails through Mandrill, supporting templates.
 
 How to install:
 ```
@@ -27,12 +27,38 @@ var server = ParseServer({
       replyTo: 'no-reply@yourdomain.com',
       // Verification email subject
       verificationSubject: 'Please verify your e-mail for *|appname|*',
-      // Verification email body
+      // Verification email body. This will be ignored when verificationTemplateName is used.
       verificationBody: 'Hi *|username|*,\n\nYou are being asked to confirm the e-mail address *|email|* with *|appname|*\n\nClick here to confirm it:\n*|link|*',
       // Password reset email subject
       passwordResetSubject: 'Password Reset Request for *|appname|*',
-      // Password reset email body
-      passwordResetBody: 'Hi *|username|*,\n\nYou requested a password reset for *|appname|*.\n\nClick here to reset it:\n*|link|*'
+      // Password reset email body. This will be ignored when passwordResetTemplateName is used.
+      passwordResetBody: 'Hi *|username|*,\n\nYou requested a password reset for *|appname|*.\n\nClick here to reset it:\n*|link|*',
+
+      /****************************************
+       * If you are using Mandrill templates: *
+       ****************************************/
+
+      //
+      // If you want to use other custom User attributes in the emails
+      // (for example: firstName, lastName), add them to the list (username and email 
+      // are pre-loaded).
+      // The merge tag in the template must be equal to the attribute's name.
+      customUserAttributesMergeTags: ['firstname', 'lastname'],
+
+      //
+      // The name of your Mandrill template for the password reset email:
+      // If you add this attribute, then passwordResetBody will be ignored.
+      // IMPORTANT: Make sure the email has the *|link|* merge tag,
+      //            it will render the url to reset the password.
+      passwordResetTemplateName: 'password-reset-template-name',
+
+      //
+      // The name of your Mandrill template for the verification email:
+      // If you add this attribute, then verificationBody will be ignored.
+      // IMPORTANT: Make sure the email has the *|link|* merge tag,
+      //            it will render the url to verify the user.
+      verificationTemplateName: 'email-verification-template-name',
+
     }
   }
   ...

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var mandrill = require('mandrill-api/mandrill');
 
 var MandrillAdapter = mandrillOptions => {
+  console.info('Using MandrillAdapter for emails.');
+
   if (
       !mandrillOptions ||
       !mandrillOptions.apiKey ||
@@ -79,20 +81,40 @@ var MandrillAdapter = mandrillOptions => {
       global_merge_vars: [
         { name: 'appname', content: options.appName},
         { name: 'username', content: options.user.get("username")},
+        { name: 'firstname', content: options.user.get("firstName")},
         { name: 'email', content: options.user.get("email")},
         { name: 'link', content: options.link}
       ]
     }
 
     return new Promise((resolve, reject) => {
+      if (mandrillOptions.passwordResetTemplateName) {
+        mandrill_client.messages.sendTemplate(
+          {
+            template_name: mandrillOptions.passwordResetTemplateName,
+            template_content: [],
+            message: message,
+            async: true
+          },
+          function(value) {
+            console.info("Password reset email sent.");
+            resolve(value);
+          },
+          function(error) {
+            console.error(error);
+            reject(error);
+          }
+        )
+      } else {
         mandrill_client.messages.send(
-        {
-          message: message,
-          async: true
-        },
-        resolve,
-        reject
-      )
+          {
+            message: message,
+            async: true
+          },
+          resolve,
+          reject
+        ) 
+      }
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-server-mandrill-adapter",
-  "version": "1.1.1",
-  "description": "Used to send Parse Server password reset and email verification emails through Mandrill",
+  "version": "1.2.0",
+  "description": "Used to send Parse Server password reset and email verification emails through Mandrill, supporting templates.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,6 +18,7 @@
     "back4app"
   ],
   "author": "Davi Macedo",
+  "contributors": ["Alvaro Larrosa <alarrosa@octobot.io>"],
   "bugs": {
     "url": "https://github.com/back4app/parse-server-mandrill-adapter/issues"
   },


### PR DESCRIPTION
I managed to use Mandrill templates for password reset and email verification emails.

Using the templates is optional and my update is backward compatible. 

I tried to keep it as simple as possible and added support for Parse User custom attributes to be optionally rendered in the emails.

Any comments?
