### PR TITLE
Fixed uncaught exception when no customUserAttributesMergeTags are set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ var MandrillAdapter = mandrillOptions => {
       mandrillOptions.passwordResetBody ||
       'Hi,\n\nYou requested a password reset for *|appname|*.\n\nClick here ' +
       'to reset it:\n*|link|*';
+  mandrillOptions.customUserAttributesMergeTags = mandrillOptions.customUserAttributesMergeTags || [];
 
   var mandrill_client = new mandrill.Mandrill(mandrillOptions.apiKey);
 


### PR DESCRIPTION
Fixes https://github.com/back4app/parse-server-mandrill-adapter/issues/5

Properly initializes customUserAttributesMergeTags without having to do a undefined check everywhere.
